### PR TITLE
Fixed issue where search query could only be one word

### DIFF
--- a/app/src/main/java/scu/csci187/fall2018/mealtracker/Classes/QueryParam.java
+++ b/app/src/main/java/scu/csci187/fall2018/mealtracker/Classes/QueryParam.java
@@ -92,7 +92,8 @@ public class QueryParam {
         }
 
         // Set query param
-        result = result + "q=" + this.query;
+        result = result + "q=" + URLEncoder.encode(this.query);
+
         if (this.healthLabels.size() < 1) {
             // Do Nothing
         } else {


### PR DESCRIPTION
Fixed by encoding the portion of the URL where the query is.